### PR TITLE
Support for parsing wall time with days

### DIFF
--- a/magpie/lib/magpie-lib-helper
+++ b/magpie/lib/magpie-lib-helper
@@ -34,6 +34,9 @@ Magpie_walltime_to_minutes () {
 		if [ "${numcolons}" == "2" ]
     	then
         	magpie_walltimetominutes=`echo ${walltime} | awk -F'-|:' '{print $1 * 24 * 60 + $2 * 60 + $3 + $4 / 60}' | xargs printf "%1.0f"`
+        elif [ "${numcolons}" == "1" ]
+    	then
+    		magpie_walltimetominutes=`echo ${walltime} | awk -F'-|:' '{print $1 * 24 * 60 + $2 * 60 + $3}' | xargs printf "%1.0f"`
     	elif [ "${numcolons}" == "0" ]
     	then
         	magpie_walltimetominutes=`echo ${walltime} | awk -F'-' '{print $1 * 24 * 60 + $2 * 60}' | xargs printf "%1.0f"`
@@ -45,6 +48,9 @@ Magpie_walltime_to_minutes () {
     	elif [ "${numcolons}" == "1" ]
     	then
         	magpie_walltimetominutes=`echo ${walltime} | awk -F':' '{print $1 + $2 / 60}' | xargs printf "%1.0f"`
+        elif [ "${numcolons}" == "0" ]
+    	then
+    		magpie_walltimetominutes=`echo ${walltime} | xargs printf "%1.0f"`	
     	fi
 	fi
 }

--- a/magpie/lib/magpie-lib-helper
+++ b/magpie/lib/magpie-lib-helper
@@ -29,14 +29,24 @@
 Magpie_walltime_to_minutes () {
     local walltime=$1
     local numcolons=`echo ${walltime} | awk -F: '{print NF-1}'`
-
-    if [ "${numcolons}" == "2" ]
-    then
-        magpie_walltimetominutes=`echo ${walltime} | awk -F':' '{print $1 * 60 + $2 + $3 / 60}' | xargs printf "%1.0f"`
-    elif [ "${numcolons}" == "1" ]
-    then
-        magpie_walltimetominutes=`echo ${walltime} | awk -F':' '{print $1 + $2 / 60}' | xargs printf "%1.0f"`
-    fi
+    if [[ $walltime == *"-"* ]]
+	then
+		if [ "${numcolons}" == "2" ]
+    	then
+        	magpie_walltimetominutes=`echo ${walltime} | awk -F'-|:' '{print $1 * 24 * 60 + $2 * 60 + $3 + $4 / 60}' | xargs printf "%1.0f"`
+    	elif [ "${numcolons}" == "0" ]
+    	then
+        	magpie_walltimetominutes=`echo ${walltime} | awk -F'-' '{print $1 * 24 * 60 + $2 * 60}' | xargs printf "%1.0f"`
+    	fi
+	else
+		if [ "${numcolons}" == "2" ]
+    	then
+        	magpie_walltimetominutes=`echo ${walltime} | awk -F':' '{print $1 * 60 + $2 + $3 / 60}' | xargs printf "%1.0f"`
+    	elif [ "${numcolons}" == "1" ]
+    	then
+        	magpie_walltimetominutes=`echo ${walltime} | awk -F':' '{print $1 + $2 / 60}' | xargs printf "%1.0f"`
+    	fi
+	fi
 }
 
 # From http://stackoverflow.com/questions/4023830/bash-how-compare-two-strings-in-version-format


### PR DESCRIPTION
Current Magpie_walltime_to_minutes does not support wall time with days(e.g. 1-2:30:00). This fix adds support for wall time with days.