### PR TITLE
On some systems ulimit cannot be changed and prints a permission denied.

### DIFF
--- a/magpie/setup/magpie-setup-project-hadoop
+++ b/magpie/setup/magpie-setup-project-hadoop
@@ -907,8 +907,8 @@ then
     then
         cat ${HADOOP_ENVIRONMENT_EXTRA_PATH} >> ${post_hadoopenvsh}
     else
-        echo "ulimit -n ${magpie_openfilescount}" >> ${post_hadoopenvsh}
-        echo "ulimit -u ${magpie_userprocessescount}" >> ${post_hadoopenvsh}
+        echo "ulimit -n ${magpie_openfilescount} &> /dev/null" >> ${post_hadoopenvsh}
+        echo "ulimit -u ${magpie_userprocessescount} &> /dev/null" >> ${post_hadoopenvsh}
     fi
 
     cp ${pre_log4jproperties} ${post_log4jproperties}
@@ -1114,8 +1114,8 @@ then
     then
         cat ${HADOOP_ENVIRONMENT_EXTRA_PATH} >> ${post_yarnenvsh}
     else
-        echo "ulimit -n ${magpie_openfilescount}" >> ${post_yarnenvsh}
-        echo "ulimit -u ${magpie_userprocessescount}" >> ${post_yarnenvsh}
+        echo "ulimit -n ${magpie_openfilescount} &> /dev/null" >> ${post_yarnenvsh}
+        echo "ulimit -u ${magpie_userprocessescount} &> /dev/null" >> ${post_yarnenvsh}
     fi
 fi
 

--- a/magpie/setup/magpie-setup-project-hbase
+++ b/magpie/setup/magpie-setup-project-hbase
@@ -246,8 +246,8 @@ if [ "${HBASE_ENVIRONMENT_EXTRA_PATH}X" != "X" ] && [ -f ${HBASE_ENVIRONMENT_EXT
 then
     cat ${HBASE_ENVIRONMENT_EXTRA_PATH} >> ${post_hbaseenvsh}
 else
-    echo "ulimit -n ${magpie_openfilescount}" >> ${post_hbaseenvsh}
-    echo "ulimit -u ${magpie_userprocessescount}" >> ${post_hbaseenvsh}
+    echo "ulimit -n ${magpie_openfilescount} &> /dev/null" >> ${post_hbaseenvsh}
+    echo "ulimit -u ${magpie_userprocessescount} &> /dev/null" >> ${post_hbaseenvsh}
 fi
 
 cp ${pre_log4jproperties} ${post_log4jproperties}

--- a/magpie/setup/magpie-setup-project-spark
+++ b/magpie/setup/magpie-setup-project-spark
@@ -578,8 +578,8 @@ if [ "${SPARK_ENVIRONMENT_EXTRA_PATH}X" != "X" ] && [ -f ${SPARK_ENVIRONMENT_EXT
 then
     cat ${SPARK_ENVIRONMENT_EXTRA_PATH} >> ${post_sparkenvsh}
 else
-    echo "ulimit -n ${magpie_openfilescount}" >> ${post_sparkenvsh}
-    echo "ulimit -u ${magpie_userprocessescount}" >> ${post_sparkenvsh}
+    echo "ulimit -n ${magpie_openfilescount} &> /dev/null" >> ${post_sparkenvsh}
+    echo "ulimit -u ${magpie_userprocessescount} &> /dev/null" >> ${post_sparkenvsh}
 fi
 
 if echo ${SPARK_VERSION} | grep -q -E "[1-2]\.[0-9]\.[0-9]"

--- a/magpie/setup/magpie-setup-project-tachyon
+++ b/magpie/setup/magpie-setup-project-tachyon
@@ -168,8 +168,8 @@ if [ "${TACHYON_ENVIRONMENT_EXTRA_PATH}X" != "X" ] && [ -f ${TACHYON_ENVIRONMENT
 then
     cat ${TACHYON_ENVIRONMENT_EXTRA_PATH} >> ${post_tachyonenvsh}
 else
-    echo "ulimit -n ${magpie_openfilescount}" >> ${post_tachyonenvsh}
-    echo "ulimit -u ${magpie_userprocessescount}" >> ${post_tachyonenvsh}
+    echo "ulimit -n ${magpie_openfilescount} &> /dev/null" >> ${post_tachyonenvsh}
+    echo "ulimit -u ${magpie_userprocessescount} &> /dev/null" >> ${post_tachyonenvsh}
 fi
 
 cp ${pre_log4jproperties} ${post_log4jproperties}


### PR DESCRIPTION
This patch prevents the error from being displayed.