### PR TITLE
Resolved SPARK_SETUP_TYPE issue in magpie-setup-project-zeppelin

### DIFF
--- a/magpie/setup/magpie-setup-project-zeppelin
+++ b/magpie/setup/magpie-setup-project-zeppelin
@@ -171,7 +171,7 @@ post_zeppelinsitexml=${ZEPPELIN_CONF_DIR}/zeppelin-site.xml
 post_log4jproperties=${ZEPPELIN_CONF_DIR}/log4j.properties
 post_shiroini=${ZEPPELIN_CONF_DIR}/shiro.ini
 
-if [ "${SPARK_SETUP_MODE}" == "YARN" ];
+if [ "${SPARK_SETUP_TYPE}" == "YARN" ];
 then
     zeppelin_spark_master="yarn-client"
 else


### PR DESCRIPTION
In magpie-setup-project-zeppelin it currently checks for SPARK_SETUP_MODE.  Correct variable name is SPARK_SETUP_TYPE