### PR TITLE
Fix redirection in  magpie-lib-run wait function

### DIFF
--- a/magpie/lib/magpie-lib-run
+++ b/magpie/lib/magpie-lib-run
@@ -68,7 +68,7 @@ __Magpie_wait_script_signal_on_timeout () {
 
     for i in `seq 1 ${scriptsleepiterations}`
     do
-        if kill -0 ${scriptpid} 2&> /dev/null
+        if kill -0 ${scriptpid} &>/dev/null
         then
             sleep 30
         else


### PR DESCRIPTION
As far as I know, redirection "2&> /dev/null" is not correct. Even though it is buggy, it does the desired behavior in most setups, but in my case, it doesn't work on centos 7 using the root account. Strange, but true.