### PR TITLE
Remove trailing whitespaces in submission scripts

### DIFF
--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun
@@ -218,10 +218,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -1217,11 +1217,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -1234,7 +1234,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 
@@ -1931,9 +1931,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop
@@ -191,10 +191,10 @@ export MAGPIE_JOB_TYPE="hadoop"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-hive
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-hive
@@ -191,10 +191,10 @@ export MAGPIE_JOB_TYPE="hive"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -905,11 +905,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -922,7 +922,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-mahout
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-mahout
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="mahout"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-pig
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hadoop-and-pig
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="pig"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hbase-with-hdfs
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hbase-with-hdfs
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="hbase"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hbase-with-hdfs-with-phoenix
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-hbase-with-hdfs-with-phoenix
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="phoenix"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-ray
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-ray
@@ -172,10 +172,10 @@ export MAGPIE_JOB_TYPE="ray"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark
@@ -191,10 +191,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-hdfs
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-hdfs
@@ -191,10 +191,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-yarn
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-yarn
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-yarn-and-hdfs
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-yarn-and-hdfs
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-zeppelin
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-spark-with-zeppelin
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="zeppelin"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -787,9 +787,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-storm
+++ b/submission-scripts/script-lsf-mpirun/magpie.lsf-mpirun-storm
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="storm"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun
@@ -225,10 +225,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -1224,11 +1224,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -1241,7 +1241,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 
@@ -1938,9 +1938,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop
@@ -198,10 +198,10 @@ export MAGPIE_JOB_TYPE="hadoop"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-hive
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-hive
@@ -198,10 +198,10 @@ export MAGPIE_JOB_TYPE="hive"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -912,11 +912,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -929,7 +929,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-mahout
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-mahout
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="mahout"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-pig
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hadoop-and-pig
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="pig"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hbase-with-hdfs
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hbase-with-hdfs
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="hbase"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hbase-with-hdfs-with-phoenix
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-hbase-with-hdfs-with-phoenix
@@ -204,10 +204,10 @@ export MAGPIE_JOB_TYPE="phoenix"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-ray
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-ray
@@ -179,10 +179,10 @@ export MAGPIE_JOB_TYPE="ray"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark
@@ -198,10 +198,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-hdfs
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-hdfs
@@ -198,10 +198,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-yarn
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-yarn
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-yarn-and-hdfs
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-yarn-and-hdfs
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-zeppelin
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-spark-with-zeppelin
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="zeppelin"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -794,9 +794,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-storm
+++ b/submission-scripts/script-msub-slurm-srun/magpie.msub-slurm-srun-storm
@@ -201,10 +201,10 @@ export MAGPIE_JOB_TYPE="storm"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh
@@ -221,10 +221,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -1220,11 +1220,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -1237,7 +1237,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 
@@ -1934,9 +1934,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="hadoop"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-hive
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-hive
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="hive"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -908,11 +908,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -925,7 +925,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-mahout
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-mahout
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="mahout"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-pig
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hadoop-and-pig
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="pig"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hbase-with-hdfs
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hbase-with-hdfs
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="hbase"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hbase-with-hdfs-with-phoenix
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-hbase-with-hdfs-with-phoenix
@@ -200,10 +200,10 @@ export MAGPIE_JOB_TYPE="phoenix"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-ray
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-ray
@@ -175,10 +175,10 @@ export MAGPIE_JOB_TYPE="ray"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-hdfs
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-hdfs
@@ -194,10 +194,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-yarn
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-yarn
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-yarn-and-hdfs
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-yarn-and-hdfs
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-zeppelin
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-spark-with-zeppelin
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="zeppelin"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -790,9 +790,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-storm
+++ b/submission-scripts/script-msub-torque-pdsh/magpie.msub-torque-pdsh-storm
@@ -197,10 +197,10 @@ export MAGPIE_JOB_TYPE="storm"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun
@@ -220,10 +220,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -1219,11 +1219,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -1236,7 +1236,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 
@@ -1933,9 +1933,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="hadoop"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-hive
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-hive
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="hive"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -907,11 +907,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -924,7 +924,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-mahout
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-mahout
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="mahout"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-pig
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hadoop-and-pig
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="pig"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hbase-with-hdfs
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hbase-with-hdfs
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="hbase"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hbase-with-hdfs-with-phoenix
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-hbase-with-hdfs-with-phoenix
@@ -199,10 +199,10 @@ export MAGPIE_JOB_TYPE="phoenix"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-ray
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-ray
@@ -174,10 +174,10 @@ export MAGPIE_JOB_TYPE="ray"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-hdfs
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-hdfs
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-yarn
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-yarn
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-yarn-and-hdfs
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-yarn-and-hdfs
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-zeppelin
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-spark-with-zeppelin
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="zeppelin"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -789,9 +789,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-storm
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-storm
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="storm"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-tensorflow
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-tensorflow
@@ -166,10 +166,10 @@ export MAGPIE_JOB_TYPE="tensorflow"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-tensorflow-horovod
+++ b/submission-scripts/script-sbatch-mpirun/magpie.sbatch-mpirun-tensorflow-horovod
@@ -186,10 +186,10 @@ export MAGPIE_JOB_TYPE="tensorflow-horovod"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun
@@ -220,10 +220,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -1219,11 +1219,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -1236,7 +1236,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 
@@ -1933,9 +1933,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="hadoop"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-hive
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-hive
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="hive"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -907,11 +907,11 @@ export HIVE_TESTBENCH_DIR="${HOME}/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -924,7 +924,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-mahout
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-mahout
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="mahout"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-pig
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hadoop-and-pig
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="pig"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hbase-with-hdfs
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hbase-with-hdfs
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="hbase"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hbase-with-hdfs-with-phoenix
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-hbase-with-hdfs-with-phoenix
@@ -199,10 +199,10 @@ export MAGPIE_JOB_TYPE="phoenix"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-ray
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-ray
@@ -174,10 +174,10 @@ export MAGPIE_JOB_TYPE="ray"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-hdfs
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-hdfs
@@ -193,10 +193,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-yarn
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-yarn
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-yarn-and-hdfs
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-yarn-and-hdfs
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="spark"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-zeppelin
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-spark-with-zeppelin
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="zeppelin"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"
@@ -789,9 +789,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-storm
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-storm
@@ -196,10 +196,10 @@ export MAGPIE_JOB_TYPE="storm"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-tensorflow
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-tensorflow
@@ -166,10 +166,10 @@ export MAGPIE_JOB_TYPE="tensorflow"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-tensorflow-horovod
+++ b/submission-scripts/script-sbatch-srun/magpie.sbatch-srun-tensorflow-horovod
@@ -186,10 +186,10 @@ export MAGPIE_JOB_TYPE="tensorflow-horovod"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-templates/magpie-hive
+++ b/submission-scripts/script-templates/magpie-hive
@@ -83,11 +83,11 @@ export HIVE_TESTBENCH_DIR="TESTBENCHDIRPREFIX/hive-testbench"
 
 # Select the type of benchmark.  Options are 'tpcds' and 'tpch'
 # The TPC Benchmark H (TPC-H) is a decision support benchmark. It
-# consists of a suite of business oriented ad-hoc queries and 
+# consists of a suite of business oriented ad-hoc queries and
 # concurrent data modifications.
 
-# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several 
-# generally applicable aspects of a decision support system, 
+# The TPC Benchmark DS (TPC-DS) is a decision support benchmark that models several
+# generally applicable aspects of a decision support system,
 # including queries and data maintenance
 # More information can be found at the Transaction Processing Council website
 
@@ -100,7 +100,7 @@ export HIVE_CLI_VERSION="beeline"
 ## Select the size of the data to generate. Size is in GB
 export HIVE_TESTBENCH_DATA_SIZE=2
 
-# Select the number of queries to run (max is determined by the number of queries in the 
+# Select the number of queries to run (max is determined by the number of queries in the
 # selected sample query directory. See hive-testbench for additional info)
 export HIVE_TESTBENCH_QUERY_COUNT=4
 

--- a/submission-scripts/script-templates/magpie-magpie-customizations
+++ b/submission-scripts/script-templates/magpie-magpie-customizations
@@ -119,10 +119,10 @@ export MAGPIE_JOB_TYPE="script"
 # export MAGPIE_POST_JOB_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/post-job-run-scripts/my-post-job-script"
 #
 # Similar to the MAGPIE_PRE_JOB_RUN and MAGPIE_POST_JOB_RUN, scripts can be
-# run after the stack is setup but prior to the script or interactive mode 
+# run after the stack is setup but prior to the script or interactive mode
 # begins. This enables frontends and other processes that depend on the stack
-# to be started up and torn down. In similar fashion the cleanup will be done 
-# immediatly after the script or interactive mode exits before the stack is 
+# to be started up and torn down. In similar fashion the cleanup will be done
+# immediately after the script or interactive mode exits before the stack is
 # shutdown.
 #
 # export MAGPIE_PRE_EXECUTE_RUN="${MAGPIE_SCRIPTS_HOME}/scripts/pre-job-run-scripts/my-pre-job-script"

--- a/submission-scripts/script-templates/magpie-zeppelin
+++ b/submission-scripts/script-templates/magpie-zeppelin
@@ -81,9 +81,9 @@ export ZEPPELIN_JOB="checkzeppelinup"
 # Zeppelin Notebook Authorization
 #
 # Set username, password, and roles for required shiro login authorization.
-# This setting must be in place prior to starting Zeppelin. The default 
-# shiro.conf file is configured with two roles, admin and role1. 'admin' 
-# allows configuration of the settings and 'role1' does not. Use ';' as a 
+# This setting must be in place prior to starting Zeppelin. The default
+# shiro.conf file is configured with two roles, admin and role1. 'admin'
+# allows configuration of the settings and 'role1' does not. Use ';' as a
 # delimiter for multiple users.
 #export ZEPPELIN_NOTEBOOK_USERS="user1,password1,admin;user2,password2,role2"
 


### PR DESCRIPTION
As trailing whitespaces were in template files, there would be propagated to newly created submission scripts using them, so I wanted to clean them up.