### PR TITLE
fixes #327: code error introduced invalid indirect expansion

### DIFF
--- a/magpie-check-inputs
+++ b/magpie-check-inputs
@@ -406,8 +406,8 @@ magpieprojects_java="HADOOP PIG MAHOUT HBASE PHOENIX SPARK KAFKA ZEPPELIN STORM 
 for project in ${magpieprojects_java}
 do
     setupvar="${project}_SETUP"
-    if [ "${!varname}X" != "X" ] \
-        && [ "${!varname}" == "yes" ]
+    if [ "${!setupvar}X" != "X" ] \
+        && [ "${!setupvar}" == "yes" ]
     then
         __Magpie_check_if_set_is_a_directory "JAVA_HOME"
     fi


### PR DESCRIPTION
It is code error because there is no variable `varname`.

After local test in Spark job, there is no invalid indirect expansion anymore.