### PR TITLE
allow to specify MAGPIE_HOSTNAME_CMD directly

### DIFF
--- a/magpie/lib/magpie-lib-helper
+++ b/magpie/lib/magpie-lib-helper
@@ -90,7 +90,19 @@ Magpie_vercomp () {
 
 # Get the hostname from the `hostname` command or an appropriate wrapper
 Magpie_get_magpie_hostname () {
-    local thishostname=`hostname`
+    local thishostname=
+    
+	if [ "${MAGPIE_HOSTNAME_CMD}X" != "X" ]
+    then
+        thishostname=`${MAGPIE_HOSTNAME_CMD}`
+        if [ $? -ne 0 ]
+        then
+            echo "Error in MAGPIE_HOSTNAME_CMD = ${MAGPIE_HOSTNAME_CMD}"
+            exit 1
+        fi
+    else
+		thishostname=`hostname`
+    fi
     if [ "${MAGPIE_HOSTNAME_CMD_MAP}X" != "X" ]
     then
         thishostname=`${MAGPIE_HOSTNAME_CMD_MAP} $thishostname`


### PR DESCRIPTION
Using this patch, one can force to use the short name or the FQDN of the hosts for matching the Slurm node names by setting:
```bash
# use short name
MAGPIE_HOSTNAME_CMD="hostname -s"

# use FQDN
MAGPIE_HOSTNAME_CMD="hostname -f"
```